### PR TITLE
Fix DistributionData implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
-# Wavefront OpenCensus Go Exporter [![Build Status][ci-img]][ci-link]
+# Wavefront OpenCensus Go Exporter [![Build Status][ci-img]][ci-link] [![Go Report Card][go-report-img]][go-report]
 
 This exporter provides OpenCensus trace and stats support to push metrics, histograms and traces into Wavefront.
 
 It builds on the [Wavefront Go SDK](https://github.com/wavefrontHQ/wavefront-sdk-go).
 
-### Usage
+## Requirements
+
+- Go 1.11 or higher
+
+## Usage
 
 1. Import the SDK and Exporter packages.
+
     ```go
     import (
         "github.com/wavefronthq/wavefront-sdk-go/senders"
         "github.com/wavefronthq/opencensus-exporter/wavefront"
         "go.opencensus.io/stats/view"
-	    "go.opencensus.io/trace"
+        "go.opencensus.io/trace"
     )
     ```
 
 2. Initialize the [Sender](https://github.com/wavefrontHQ/wavefront-sdk-go#usage) and Exporter.
+
     ```go
     sender, _ := senders.NewProxySender(senders.ProxyConfiguration{/*...*/})
     exporter, _ = wavefront.NewExporter(sender, /*options...*/)
@@ -26,9 +32,11 @@ It builds on the [Wavefront Go SDK](https://github.com/wavefrontHQ/wavefront-sdk
         sender.Close()
     }()
     ```
+
     The exporter supports functional options. See [Exporter Options](#exporter-options)
 
 3. Register the exporter
+
     ```go
     trace.RegisterExporter(exporter)    // for exporting traces
     view.RegisterExporter(exporter)     // for exporting metrics
@@ -36,7 +44,7 @@ It builds on the [Wavefront Go SDK](https://github.com/wavefrontHQ/wavefront-sdk
 
 4. Instrument your code using OpenCensus. Learn more at [https://opencensus.io/quickstart/go/](https://opencensus.io/quickstart/go/) 
 
-### Exporter Options
+## Exporter Options
 
 | Option                                  | Description                                                                                                                       |
 |-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
@@ -47,16 +55,29 @@ It builds on the [Wavefront Go SDK](https://github.com/wavefrontHQ/wavefront-sdk
 | `DisableSelfHealth()`                   | Disables reporting exporter health such as dropped metrics, spans, etc...                                                         |
 | `VerboseLogging()`                      | Logs individual errors to stderr                                                                                                  |
 
-
 See [examples folder](https://github.com/wavefrontHQ/opencensus-exporter/examples) for a complete example.
 
-### Requirements
-- Go 1.9 or higher
+## [`view.DistributionData`](https://godoc.org/go.opencensus.io/stats/view#DistributionData) Notes
 
-### Links
+Currently, `DistributionData` views will appear as a collection of 5 metrics in Wavefront. 
+
+For example, if a metric name is `my.dist.metric`, it's represented in Wavefront as-
+
+```go
+my.dist.metric.count        // represents DistributionData.Count
+my.dist.metric.min          // represents DistributionData.Min  
+my.dist.metric.max          // represents DistributionData.Max  
+my.dist.metric.mean         // represents DistributionData.Mean 
+my.dist.metric.sumsq        // represents DistributionData.SumOfSquaredDev
+```
+
+## Links
 
 - https://opencensus.io/exporters/supported-exporters/go/wavefront/
+- https://opencensus.io/service/exporters/wavefront/
 
 
 [ci-img]: https://travis-ci.com/wavefrontHQ/opencensus-exporter.svg?branch=master
 [ci-link]: https://travis-ci.com/wavefrontHQ/opencensus-exporter
+[go-report-img]: https://goreportcard.com/badge/github.com/wavefronthq/opencensus-exporter
+[go-report]: https://goreportcard.com/report/github.com/wavefronthq/opencensus-exporter

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -88,12 +88,12 @@ func main() {
 
 func parent(ctx context.Context) {
 	ctx, span := trace.StartSpan(ctx, "main")
-	start_time := time.Now()
+	startTime := time.Now()
 	for i := 0; i < 5; i++ {
 		stats.Record(ctx, totalWorks.M(1))
 		work(ctx, i+1)
 	}
-	stats.Record(ctx, workTime.M(time.Since(start_time).Nanoseconds()/1e6))
+	stats.Record(ctx, workTime.M(time.Since(startTime).Nanoseconds()/1e6))
 	time.Sleep(500 * time.Millisecond)
 	span.End()
 }
@@ -102,6 +102,6 @@ func work(ctx context.Context, index int) {
 	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("work-%d", index))
 	defer span.End()
 
-	rand_time := 100 + rand.Int63n(100)
-	time.Sleep(time.Duration(rand_time) * time.Millisecond) // work
+	randTime := 100 + rand.Int63n(100)
+	time.Sleep(time.Duration(randTime) * time.Millisecond) // work
 }

--- a/wavefront/ocservice_helpers.go
+++ b/wavefront/ocservice_helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wavefronthq/wavefront-sdk-go/application"
 )
 
+// ServiceOptions is used for opencensus-service exporter
 type ServiceOptions struct {
 	SourceOverride    *string           `mapstructure:"override_source,omitempty"`
 	ApplicationName   *string           `mapstructure:"application_name,omitempty"`
@@ -16,6 +17,7 @@ type ServiceOptions struct {
 	VerboseLogging    *bool             `mapstructure:"verbose_logging,omitempty"`
 }
 
+// WithServiceOptions is used for opencensus-service exporter
 func WithServiceOptions(so *ServiceOptions) Option {
 	return func(o *Options) {
 		if so.SourceOverride != nil {

--- a/wavefront/selfhealth.go
+++ b/wavefront/selfhealth.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	DefaultSelfReportDuration = 5 * time.Minute
+	// DefaultSelfReportInterval specifies self-health report interval
+	DefaultSelfReportInterval = 5 * time.Minute
 	metDropReportName         = "opencensus.exporter.dropped_metrics"
 	spanDropReportName        = "opencensus.exporter.dropped_spans"
 	senderErrorsReportName    = "opencensus.exporter.sender_errors"
@@ -24,11 +25,11 @@ type _SelfMetrics struct {
 // ReportSelfHealth sends exporter specific metrics to wavefront
 // Currently, only dropped span & metric counts are reported
 func (e *Exporter) ReportSelfHealth() {
-	e.reportStart(DefaultSelfReportDuration)
+	e.reportStart(DefaultSelfReportInterval)
 }
 
 func (e *Exporter) reportStart(d time.Duration) {
-	e.selfHealthTicker = time.NewTicker(DefaultSelfReportDuration)
+	e.selfHealthTicker = time.NewTicker(DefaultSelfReportInterval)
 	e.stopSelfHealth = make(chan struct{})
 	go func() {
 		for {
@@ -93,7 +94,7 @@ func (e *Exporter) sendSelfHealth() {
 	}
 
 	if err != nil {
-		e.logError("Report SelfHealth failed:", err)
+		e.logError("Report SelfHealth failed", err)
 	}
 }
 
@@ -103,7 +104,7 @@ func (e *Exporter) SpansDropped() uint64 {
 	return atomic.LoadUint64(&e.spansDropped)
 }
 
-// SpansDropped counts metrics dropped
+// MetricsDropped counts metrics dropped
 // when exporter queue is full
 func (e *Exporter) MetricsDropped() uint64 {
 	return atomic.LoadUint64(&e.metricsDropped)

--- a/wavefront/trace.go
+++ b/wavefront/trace.go
@@ -132,22 +132,22 @@ func (e *Exporter) processSpan(sd *trace.SpanData) {
 
 	startTime := sd.StartTime.UnixNano() / nanoToMillis
 	endTime := sd.EndTime.Sub(sd.StartTime).Nanoseconds() / nanoToMillis
-	traceId := convertTraceId(sd.TraceID)
-	spanId := convertSpanId(sd.SpanID)
+	traceID := convertTraceID(sd.TraceID)
+	spanID := convertSpanID(sd.SpanID)
 	var parents []string
 	pspanBytes := [8]byte(sd.ParentSpanID)
 	if !bytes.Equal(zeroSpanID[:], pspanBytes[:]) { //don't add parent in case of root span
-		parents = []string{convertSpanId(sd.ParentSpanID)}
+		parents = []string{convertSpanID(sd.ParentSpanID)}
 	}
 
 	cmd := func() {
 		defer e.semRelease()
 
-		e.logError("Error sending span: ", e.sender.SendSpan(
+		e.logError("Error sending span", e.sender.SendSpan(
 			sd.Name,
 			startTime, endTime,
 			e.Source,
-			traceId, spanId, parents, nil,
+			traceID, spanID, parents, nil,
 			spanTags, spanLogs,
 		))
 	}
@@ -157,7 +157,7 @@ func (e *Exporter) processSpan(sd *trace.SpanData) {
 	}
 }
 
-func convertTraceId(val trace.TraceID) string {
+func convertTraceID(val trace.TraceID) string {
 	b := [36]byte{}
 	copy(b[:], zeroUUID) //TODO: directly set '-'?
 	hex.Encode(b[:], val[:4])
@@ -168,7 +168,7 @@ func convertTraceId(val trace.TraceID) string {
 	return string(b[:])
 }
 
-func convertSpanId(val trace.SpanID) string {
+func convertSpanID(val trace.SpanID) string {
 	// RFC4122 format
 	b := [36]byte{}
 	copy(b[:], zeroUUID)

--- a/wavefront/wavefront_test.go
+++ b/wavefront/wavefront_test.go
@@ -310,7 +310,11 @@ func TestProcessView(tt *testing.T) {
 	sender.TestData["v1"] = []interface{}{"v1", float64(4.5), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v1unit"}}
 	sender.TestData["v2"] = []interface{}{"v2", float64(4), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v1unit"}}
 	sender.TestData["v3"] = []interface{}{"v3", float64(4), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v3unit"}}
-	sender.TestData["v4"] = []interface{}{"v4", []histogram.Centroid{histogram.Centroid{Value: 9, Count: 1}, histogram.Centroid{Value: 20, Count: 2}, histogram.Centroid{Value: 37, Count: 1}}, map[histogram.Granularity]bool{0: true}, int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
+	sender.TestData["v4.max"] = []interface{}{"v4.max", float64(27), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
+	sender.TestData["v4.mean"] = []interface{}{"v4.mean", float64(18), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
+	sender.TestData["v4.count"] = []interface{}{"v4.count", float64(2), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
+	sender.TestData["v4.sumsq"] = []interface{}{"v4.sumsq", float64(0), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
+	sender.TestData["v4.min"] = []interface{}{"v4.min", float64(9), int64(67890001), "FakeSource", map[string]string{"application": "test-app", "cluster": "none", "service": "test-service", "shard": "none", "unit": "v4unit"}}
 
 	fakeExp, _ := NewExporter(sender, Source("FakeSource"), AppTags(appTags), Granularity(histogram.MINUTE), DisableSelfHealth())
 
@@ -458,7 +462,7 @@ func BenchmarkProcessView(bb *testing.B) {
 	})
 	bb.Run("Distribution", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			benchExp.processView(vd2)
+			benchExp.processView(vd4)
 		}
 	})
 }


### PR DESCRIPTION
This also fixes exporter segfault due to some changes in OC-Go 0.20.0. (Fixes #4)
Specifically, census-instrumentation/opencensus-go/pull/1127

Also, `wavefront.Granularity` doesn't need to be specified now. (Closes #5)
The option is still kept because we can add WavefrontHistogram in the future.

