### PR TITLE
Fixes compile error

### DIFF
--- a/wavefront/ocservice_helpers.go
+++ b/wavefront/ocservice_helpers.go
@@ -24,7 +24,8 @@ func WithServiceOptions(so *ServiceOptions) Option {
 			o.Source = *so.SourceOverride
 		}
 		if so.ApplicationName != nil && so.ServiceName != nil {
-			o.appMap = application.New(*so.ApplicationName, *so.ServiceName).Map()
+			app := application.New(*so.ApplicationName, *so.ServiceName)
+			o.appMap = app.Map()
 		}
 		if so.CustomTags != nil {
 			for k, v := range so.CustomTags {


### PR DESCRIPTION
resolves compile error when calling chained pointer method

```
# github.com/wavefronthq/opencensus-exporter/wavefront
vendor/github.com/wavefronthq/opencensus-exporter/wavefront/ocservice_helpers.go:27:68: cannot call pointer method on application.New(*so.ApplicationName, *so.ServiceName)
vendor/github.com/wavefronthq/opencensus-exporter/wavefront/ocservice_helpers.go:27:68: cannot take the address of application.New(*so.ApplicationName, *so.ServiceName)
```